### PR TITLE
Terraform apply fails for sensitive values

### DIFF
--- a/modules/mock_ec2_instance/main.tf
+++ b/modules/mock_ec2_instance/main.tf
@@ -13,3 +13,21 @@ locals {
 output "instances" {
   value = local.instances
 }
+
+
+# Used by Alternate strategy using jsonencode()
+
+locals {
+  spot_instances = [
+    for i, v in var.spot_instances : merge(
+      v,
+      {
+        user_data = "# ${var.bootstrap_token}"
+      }
+    )
+  ]
+}
+
+output "spot_instances" {
+  value = local.spot_instances
+}

--- a/modules/mock_ec2_instance/variables.tf
+++ b/modules/mock_ec2_instance/variables.tf
@@ -11,3 +11,12 @@ variable "instances" {
     key_name = string
   }))
 }
+
+
+variable "spot_instances" {
+  description = "List of spot instance meta-data objects"
+  type = list(object({
+    name     = string
+    key_name = string
+  }))
+}

--- a/stacks/error_with_module/main.tf
+++ b/stacks/error_with_module/main.tf
@@ -3,14 +3,39 @@ module "host" {
 
   instances       = var.instances
   bootstrap_token = var.bootstrap_token
+  spot_instances  = var.spot_instances
 }
 
 locals {
-  unique_keys = { for k in toset(module.host.instances[*].key_name) : k => true }
+  unique_keys = [for k in toset(module.host.instances[*].key_name) : { "key_name" : k, "content" : "true" }]
+
 }
 
+/*
+* Strategy 1: It seems like when Terraform leverages functions to create values from sensitive values,
+* those functions tend to return the transformed values as sensitive, i.e. internally they are marked as sensitive.
+* In this case, it's probably the func merge(). It also seems to occur in func keys() for map.
+* This strategy uses count , basically countering the for-each evaluation,which checks if the mark sensitive on the created values.
+*/
 resource "local_sensitive_file" "keys" {
-  for_each = local.unique_keys
+  count = length(local.unique_keys)
+
+  filename        = "${path.module}/${lookup(local.unique_keys[count.index], "key_name")}"
+  content         = lookup(local.unique_keys[count.index], "content")
+  file_permission = "0600"
+}
+
+
+/*
+* Strategy 2: Alternative way to achieve without modifying the original oject(i.e. containing keyname and true)
+* The hack basically converts the attributes to string and then vice-versa. This is probably a bit cleaner,as it does
+* uses count.
+*/
+locals {
+  unique_spot_keys = { for k in nonsensitive(jsondecode(jsonencode(module.host.spot_instances[*]))) : k.key_name => true }
+}
+resource "local_sensitive_file" "spot_keys" {
+  for_each = local.unique_spot_keys
 
   filename        = "${path.module}/${each.key}"
   content         = each.value

--- a/stacks/error_with_module/terraform.tfvars
+++ b/stacks/error_with_module/terraform.tfvars
@@ -1,7 +1,22 @@
 bootstrap_token = "supersecret"
 instances = [
   {
-    name     = "my-ec2-instance"
-    key_name = "my-ec2-key"
+    name     = "my-ec2-instance-0"
+    key_name = "my-ec2-key-0"
+  },
+  {
+    name     = "my-ec2-instance-1"
+    key_name = "my-ec2-key-1"
+  }
+]
+
+spot_instances = [
+  {
+    name     = "my-ec2-spot-instance-0"
+    key_name = "my-ec2-spot-key-0"
+  },
+  {
+    name     = "my-ec2-spot-instance-1"
+    key_name = "my-ec2-spot-key-1"
   }
 ]

--- a/stacks/error_with_module/variables.tf
+++ b/stacks/error_with_module/variables.tf
@@ -11,3 +11,11 @@ variable "instances" {
     key_name = string
   }))
 }
+
+variable "spot_instances" {
+  description = "List of spot instance meta-data objects"
+  type = list(object({
+    name     = string
+    key_name = string
+  }))
+}


### PR DESCRIPTION
## Description:
Terraform apply fails when using transformed attributes from sensitive values. More info at this [Github Issue](https://github.com/hashicorp/terraform/issues/32880)

### Fix :
Currently, there are two workarounds which are added in this fix. 

#### Strategy 1 :
 uses count to counter the for-each evaluation of  values which are transformed from sensitive values.It seems like terraform some how marks the transformed object as sensitive , even though there are no sensitive values in the transformed object. This can be verified using nonsensitive() func.

#### Strategy 2: 
uses jsonencode() func to ensure the transformed object is converted into string and vice-versa. This is probably a cleaner approach than using count. The resource used for this approach is knows module.host.spot_instances. Separate variables and separate resources for spot_keys are used to keep it simple.

`Note: Both these approaches follow the initial requirement of not moving the logic from child module to root module.`

